### PR TITLE
feat: setup ci with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: yarn typescript
 
       - name: Test
-        run: yarn jest
+        run: yarn test
 
       - name: Build
         run: yarn prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: |
+            ~/cache
+            !~/cache/exclude
+            **/node_modules
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Linting
+        run: yarn lint
+
+      - name: Types
+        run: yarn typescript
+
+      - name: Test
+        run: yarn jest
+
+      - name: Build
+        run: yarn prepare


### PR DESCRIPTION
## Overview
Closes #3 

I created a ci to run on all pull requests to prevent problems with tests, linting, and build.

I did not make automatic publish on release yet because I don't found a good solution to did it with release-it. We have a lot of ways to try to automate publishing, and I need your help to pick the best solution for this project.

*Suggestion*: we can remove release-it and make a workflow with `semantic-release` like I did on [this commit](https://github.com/akinncar/react-native-mask-text/commit/e6e11dcb25aeadf49c73ff469a9497371e1a7002) for react-native-mask-text library.
semantic-release can make automatic release and publish when you merge to main (or to a release branch) and it [automatically resolves semantic versions according to your commit merge messages](https://github.com/semantic-release/semantic-release#commit-message-format).

## Todo

- [X] ci tests on pull request
- [X] ci linting on pull request
- [ ] publish to npm on release