### PR TITLE
fix: Change breakpoint when screen resizes

### DIFF
--- a/src/ScreenProvider.tsx
+++ b/src/ScreenProvider.tsx
@@ -68,9 +68,7 @@ export function ScreenProvider({
 
   const handleScreenResize = useCallback(
     ({ window }: { window: ScaledSize }) => {
-      const screenBreakpoint = getBreakpointByScreenWidth(
-        Math.min(window.width, window.height)
-      );
+      const screenBreakpoint = getBreakpointByScreenWidth(window.width);
 
       if (screenBreakpoint !== currentBreakpoint.current) {
         setBreakpoint(screenBreakpoint);

--- a/src/ScreenProvider.tsx
+++ b/src/ScreenProvider.tsx
@@ -69,7 +69,7 @@ export function ScreenProvider({
   const handleScreenResize = useCallback(
     ({ window }: { window: ScaledSize }) => {
       const screenBreakpoint = getBreakpointByScreenWidth(
-        Math.max(window.width, window.height)
+        Math.min(window.width, window.height)
       );
 
       if (screenBreakpoint !== currentBreakpoint.current) {


### PR DESCRIPTION
Previously when the device had the screen rotated it would always take the larger value between height and width. This was bad because the brekpoint was not changed.

The dimensions changes listener returns the correct width and height values ​​depending on the orientation, so no extra checking is needed.

<p align="center">
  <img src="https://user-images.githubusercontent.com/26551306/145047538-55ba8c7b-1d67-4bcb-b128-af590c5aa3a1.png" width="250" />
  <img src="https://user-images.githubusercontent.com/26551306/145047574-e1b34506-3fc4-4a43-b755-638f01315e53.png" width="350" />
</p>

