### PR TITLE
removeEventListener has been deprecated

### DIFF
--- a/src/ScreenProvider.tsx
+++ b/src/ScreenProvider.tsx
@@ -86,10 +86,10 @@ export function ScreenProvider({
   }, [breakpoint]);
 
   useEffect(() => {
-    Dimensions.addEventListener('change', handleScreenResize);
+    const eventSubscription = Dimensions.addEventListener('change', handleScreenResize);
 
     return () => {
-      Dimensions.removeEventListener('change', handleScreenResize);
+      eventSubscription.remove()
     };
   }, [handleScreenResize]);
 


### PR DESCRIPTION
Hi dev !! 
removeEnventListener in ScreenProvider has been deprecated and throws warnings when tested with jest so I made the following change. :smile: :+1: 